### PR TITLE
Add release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Automatic release/publish pipeline.

You'll need to do two things to set it up: one mandatory and one optional.

Mandatory step:
1. generate a publish token on crates.io (preferably scoped to avra-rs, needs only "publish new packages" permission)
2. Paste it into an env var called `CARGO_REGISTRY_TOKEN` in github:
<img width="1151" alt="image" src="https://github.com/user-attachments/assets/55abb2c9-80f0-4880-97fe-927c270c7c1e">

Optional step:
1. Add branch protection on the `master` branch, forbid direct commits.

If you don't - release-plz will trigger a release immediately after a merge to `master` and will commit a new release into `master` directly.
With protection, release-plz will create a PR with all the changes it wants to do and only after this PR is _merged_ it will make a tag and a release, so this lets review changes before releasing.

(First release might need to be patched manually a bit to synchronize changelog to what release-plz expects.)